### PR TITLE
added suppress annotation so a signed .apk can be built

### DIFF
--- a/GardenApp/app/src/main/java/com/cs1530_group1/gardenapp/DrawingThread.java
+++ b/GardenApp/app/src/main/java/com/cs1530_group1/gardenapp/DrawingThread.java
@@ -1,4 +1,5 @@
 package com.cs1530_group1.gardenapp;
+import android.annotation.SuppressLint;
 import android.graphics.Canvas;
 
 /**
@@ -29,6 +30,7 @@ public class DrawingThread extends Thread {
     /**
      * run : the drawing thread
      */
+    @SuppressLint("WrongCall")
     public void run() {
         while (running) {
             Canvas c = null;


### PR DESCRIPTION
@SuppressLint("WrongCall")

is needed so .Draw() doesn't cause an error when trying to make a signed .apk

The normal unsigned .apk can still be built without this @ annotation 
