### PR TITLE
When the GardenView was being minimized, the DrawingThread was being …

### DIFF
--- a/GardenApp/app/src/main/java/com/cs1530_group1/gardenapp/GardenView.java
+++ b/GardenApp/app/src/main/java/com/cs1530_group1/gardenapp/GardenView.java
@@ -67,7 +67,7 @@ public class GardenView extends SurfaceView {
         garden = g;
 
         // Create the drawing thread
-        drawingThread = new DrawingThread(this);
+        createDrawingThread();
 
         // Set the listener
         this.setOnTouchListener(new GardenTouchListener() );
@@ -86,6 +86,13 @@ public class GardenView extends SurfaceView {
         newPlant = new ShapeDrawable(new OvalShape());
         //newPlant.setBounds(positionToBounds(newPlant_x, newPlant_y, newPlant_size));
         newPlant.getPaint().setColor(Color.GREEN);
+    }
+
+    /** createDrawingThread :
+     *  allows inner classes to create the drawing thread during onCreate()
+     */
+    protected void createDrawingThread() {
+        drawingThread = new DrawingThread(this);
     }
 
     /**
@@ -252,12 +259,17 @@ public class GardenView extends SurfaceView {
 
     }
 
-        /**
-         * surfaceCreated : Creates the drawing thread when the application first starts
-          * @param h : passed in automatically
-         */
+    /**
+     * surfaceCreated : Creates the drawing thread when the application first starts
+      * @param h : passed in automatically
+     */
     public void surfaceCreated(SurfaceHolder h)
     {
+        // When the Drawing Activity is minimized, the thread goes to the Terminated state
+        // When it is brought back up, it is still in Terminated state -- just create a new thread
+        // and start it
+        if (drawingThread.getState() == Thread.State.TERMINATED) createDrawingThread();
+
         drawingThread.setRunning(true);
         drawingThread.start();
         return;


### PR DESCRIPTION
…terminated.

OnCreate() needed to create a new DrawingThread if the current one was in the
terminated state.

Refactored code so that creating the DrawingThread is in a small method that
is called in the GardenView constructor and in OnCreate() in the private
inner class.
