### PR TITLE
Fixed bug where rotating screen several times in a row crashed the Ga…

### DIFF
--- a/GardenApp/app/src/main/AndroidManifest.xml
+++ b/GardenApp/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".GardenDrawingActivity"
-            android:label="GardenDrawingActivity" >
+            android:label="GardenDrawingActivity"
+            android:screenOrientation="landscape">
         </activity>
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
…rden Drawing Activity

Solution: Setting the screenOrientation to landscape in the manifest file. This
forces the Garden Drawing Activity to be drawn as landscape.

Rotating the emulator screen rapidly no longer causes the Garden Drawing Activity
to crash.
